### PR TITLE
优化windows 平台打开二维码的方式

### DIFF
--- a/vchat/config.py
+++ b/vchat/config.py
@@ -6,7 +6,6 @@ import sys
 logger = logging.getLogger("vchat")
 BASE_URL = "https://login.weixin.qq.com"
 OS = sys.platform  # linux, win32,darwin
-DEFAULT_QR = "QR.svg"
 TIMEOUT = 120
 
 USER_AGENT = (

--- a/vchat/core/interface.py
+++ b/vchat/core/interface.py
@@ -12,7 +12,7 @@ from vchat.storage import Storage
 
 
 class CoreInterface(ABC):
-    def __init__(self):
+    def __init__(self) -> None:
         self._alive = False
         self._storage: Storage = Storage()
         self._net_helper: NetHelper = NetHelper()
@@ -29,10 +29,10 @@ class CoreInterface(ABC):
     @abstractmethod
     def _login(
         self,
-        enable_cmd_qr=False,
-        pic_path=None,
-        qr_callback=None,
-        login_callback=None,
+        enable_cmd_qr,
+        pic_path : Path,
+        qr_callback,
+        login_callback,
     ):
         pass
 
@@ -40,8 +40,8 @@ class CoreInterface(ABC):
     def get_qr(
         self,
         uuid: Optional[str] = None,
-        enable_cmd_qr=False,
-        pic_path: Optional[str] = None,
+        enable_cmd_qr : bool =False,
+        pic_path: Path = Path("QR.svg"),
         qr_callback=None,
     ):
         pass
@@ -197,7 +197,7 @@ class CoreInterface(ABC):
         hot_reload=True,
         status_storage_path: Path | str = Path("vchat.pkl"),
         enable_cmd_qr=False,
-        pic_path=None,
+        pic_path : Path= Path("QR.svg"),
         qr_callback=None,
         login_callback=None,
     ):

--- a/vchat/core/register.py
+++ b/vchat/core/register.py
@@ -26,7 +26,7 @@ class CoreRegisterMixin(CoreInterface, ABC):
         hot_reload=True,
         status_storage_path: Path | str = Path("vchat.pkl"),
         enable_cmd_qr=False,
-        pic_path=None,
+        pic_path : Path= Path("QR.svg"),
         qr_callback=None,
         login_callback=None,
     ):

--- a/vchat/utils.py
+++ b/vchat/utils.py
@@ -78,15 +78,16 @@ def msg_formatter(text):
     return text
 
 
-def print_qr(file_path):
+def open_qr(file_path) -> bool:
     if config.OS == "linux":
-        subprocess.call(["xdg-open", file_path])
+        result = subprocess.run(["xdg-open", file_path])
     elif config.OS == "win32":
-        subprocess.call(["start", file_path])
+        result = subprocess.run(["powershell", "-Command", "Invoke-Item", file_path])
     elif config.OS == "darwin":
-        subprocess.call(["open", file_path])
+        result = subprocess.run(["open", file_path])
     else:
         raise NotImplementedError
+    return result.returncode == 0
 
 
 def search_dict_list(contact_list: list["Contact"], key, value):


### PR DESCRIPTION
# 背景
vchat是一个跨平台软件，需要在linux，windows，macos平台运行，也有在服务器上运行的需求，此时机器没有安装图形化界面，或者用户无法访问图形化界面，需要以多种方式让用户最方便的完成扫码登录的流程
# 现状
目前的打开二维码引导用户扫码的流程中，默认使用各平台自带的能力，使用用户设置的默认 svg 查看工具打开二维码。如果设置了`enable_cmd_qr`，则在终端中打印二维码
## 缺陷
1. 使用用户设置的默认 svg 查看工具打开二维码这个步骤涉及各平台诸多细节，最后的效果可能不是用户期望的，已有相关issue反映此类问题 #4 #8 
2. 在终端打印二维码的效果受终端字体，背景颜色 等设置影响
# 尝试改进
## 改进目标
1. 尽可能简单  
扫码作为 vchat 非核心功能，应该使用尽可能简单的方法和机制
2. 错误容忍度高
在各平台尽量减少无法打开二维码的情况
## 改进方案
1. 在不设置`enable_cmd_qr=True`时，优先使用用户设置的默认 svg 查看工具打开二维码。如果子进程执行失败，回退到终端打印二维码
2. 在 windows 平台使用 powershell 提供的 cmdlet `invoke-item`打开二维码
---
`invoke-item`与其他命令的区别
`explorer`命令在`.svg`关联的文件类型没有打开方式时，无法正确打开.svg文件，见 #4


`start`命令在powershell中是`Start-Process`的别名，`Start-Process`指定了非可执行文件时，会使用该文件类型关联的程序打开这个文件，效果等同于`Invoke-Item`


`start`命令在cmd中也能指定一个非可执行文件，效果同`Invoke-Item`，但需要cmd开启shell extension，而这个选项默认是由注册表项
```
HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor\EnableExtensions\REG_DWORD
```
和
```
HKEY_CURRENT_USER\Software\Microsoft\Command Processor\EnableExtensions\REG_DWORD
```
控制的

相比以上方案`Invoke-Item`是成功率最高，语义最符合的命令
## 一些特殊场合
1. svg 文件使用频率低于其他流行图片格式，用户计算机上可能没有svg 查看器（概率极低，已知浏览器能够打开 svg 文件），此时能够回退到终端打印二维码
2. 用户可能没有设置.svg文件的打开方式，在 windows 平台`invoke-item`能够弹出open with dialog，引导用户选择一个程序打开svg文件
3. 用户可能错误的设置了.svg的打开方式，例如默认打开方式为PhotoShop或VSCode（svg 编辑器），一般认为用户设置的默认打开方式就是他期望的打开方式，所以即使这种打开方式可能不符合预期，但 vchat不对此场景做出任何特殊处理
4. 同三，用户可能设置使用一个不能打开 svg 文件的程序作为 svg 文件的默认打开方式（或者一个不存在的程序），与三不同的是，此时子进程返回码非零，vchat 认为打开 svg 文件失败，回退到终端打印二维码
# 改进带来的影响
本次改动破坏了`enable_cmd_qr`的语义，即使设置`enable_cmd_qr=False`，也有可能在终端打印二维码，为了后向兼容性不对`enable_cmd_qr`参数名做出修改

---
参考资料
- [Start-Process (Microsoft.PowerShell.Management) - PowerShell | Microsoft Learn](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-process?view=powershell-7.4#description)
- [start | Microsoft Learn](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start)
- [cmd | Microsoft Learn](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd)
- [subprocess — Subprocess management — Python 3.13.0 documentation](https://docs.python.org/3/library/subprocess.html#subprocess.run)
- [CreateProcessA function (processthreadsapi.h) - Win32 apps | Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa)