### PR TITLE
对 model.Message 添加 create_time 字段

### DIFF
--- a/vchat/core/messages.py
+++ b/vchat/core/messages.py
@@ -108,7 +108,12 @@ class CoreMessageMixin(CoreInterface, ABC):
                 m, self._net_helper, is_at_me
             )
             msg = Message(
-                from_contact, to_contact, content, m["MsgId"], chatroom_sender
+                from_=from_contact,
+                to=to_contact,
+                content=content,
+                message_id=m["MsgId"],
+                chatroom_sender=chatroom_sender,
+                create_time=m.create_time,
             )
             yield msg
 

--- a/vchat/model/message.py
+++ b/vchat/model/message.py
@@ -71,6 +71,7 @@ class Message:
     content: Content
     message_id: str
     chatroom_sender: ChatroomMember | None = None
+    create_time: int = -1
 
     def __repr__(self):
         return f"<Message: {self.from_} -> {self.to}: {self.content}>"
@@ -84,4 +85,5 @@ class Message:
             "chatroom_sender": (
                 None if self.chatroom_sender is None else self.chatroom_sender.todict()
             ),
+            "create_time": self.create_time,
         }


### PR DESCRIPTION
### 修改原因
由于微信在设备登录成功之后会将历史消息下发，需要给 `Message` 添加时间戳以更好判断是否是历史消息。

### 改动
给 `model.Message` 类添加了 `int` 类型的 `create_time` 字段，代表时间戳，并且会在 `CoreMessageMixin._produce_msg()` 中被赋值。